### PR TITLE
Add earliest_datetime and fix small parsing error

### DIFF
--- a/collectors/htcondor/config.py
+++ b/collectors/htcondor/config.py
@@ -4,6 +4,7 @@ import re
 from argparse import Namespace
 from functools import reduce
 from typing import List, Tuple, Union, Iterator
+from datetime import date, datetime as dt
 
 from utils import extract_values
 from exceptions import MalformedConfigEntryError, MissingConfigEntryError
@@ -15,6 +16,7 @@ class Config(object):
         "interval": 900,
         "log_level": "INFO",
         "log_file": None,
+        "earliest_datetime": date.today().isoformat(),
         "class_ads": [
             "GlobalJobId",
             "ClusterId",
@@ -56,6 +58,7 @@ class Config(object):
             (["addr"], str),
             (["port"], int),
             (["interval"], int),
+            (["earliest_datetime"], str),
             (["log_level"], str),
             (["state_db"], str),
             (["record_prefix"], str),
@@ -141,6 +144,13 @@ class Config(object):
                 except re.error:
                     raise MalformedConfigEntryError(
                         keys, "Must be a valid regular expression"
+                    )
+            elif keys[-1] == "earliest_datetime":
+                try:
+                    dt.fromisoformat(value)
+                except (TypeError, ValueError):
+                    raise MalformedConfigEntryError(
+                        keys, "Must be a valid ISO 8601 datetime string"
                     )
             if len(keys) > 1:
                 if keys[-2] == "only_if":

--- a/collectors/htcondor/config.py
+++ b/collectors/htcondor/config.py
@@ -37,6 +37,7 @@ class Config(object):
             set(self._config["class_ads"]).union(set(extract_values("key", file)))
         )
         self.check()
+        self._config["condor_timestamp"] = int(dt.fromisoformat(self.earliest_datetime).timestamp())
 
     def __getattr__(self, attr: str):
         return self._config[attr]
@@ -147,6 +148,7 @@ class Config(object):
                     )
             elif keys[-1] == "earliest_datetime":
                 try:
+                    assert isinstance(value, str)  # For type checking
                     dt.fromisoformat(value)
                 except (TypeError, ValueError):
                     raise MalformedConfigEntryError(


### PR DESCRIPTION
Hi, two suggestions:

1) I've added the possibility to specify an earliest datetime as in the SLURM collector. Depending on the setup you might not want to read out the entire history.

2) The parsing can fail if the last field in the condor_history output is empty.
Then, after stripping the last line will end on ',' instead of ', ' which makes the comma part of the last field...
Also, I think we do not want to truncate fields (hence the '-wide')